### PR TITLE
Codeceptjs Saucehelper implementation

### DIFF
--- a/CO-LOCATE.md
+++ b/CO-LOCATE.md
@@ -1,5 +1,7 @@
 
-# Co-Locate/Add CodeceptJS-Cucumber E2E Framework to your existing Project
+# Get Started with CodeceptJS tests 
+
+>> Colocate the tests to your repository
 
 ### Step 1: Clone the repository
 

--- a/packages/codeceptjs-cucumber/package.json
+++ b/packages/codeceptjs-cucumber/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-cucumber",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "CodeceptJs Cucumber ",
   "scripts": {
     "clean": "rimraf tests/acceptance/report/*.*",
@@ -22,7 +22,7 @@
     "@wdio/selenium-standalone-service": "^5.8.4",
     "allure-commandline": "^2.9.0",
     "codeceptjs": "^2.2.0",
-    "codeceptjs-saucelabs": "^1.0.8",
+    "codeceptjs-saucelabs": "^1.0.9",
     "codeceptjs-selenium": "^1.0.2",
     "debug": "^4.1.1",
     "deepmerge": "^3.2.0",

--- a/packages/codeceptjs-cucumber/package.json
+++ b/packages/codeceptjs-cucumber/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-cucumber",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "CodeceptJs Cucumber ",
   "scripts": {
     "clean": "rimraf tests/acceptance/report/*.*",
@@ -22,7 +22,7 @@
     "@wdio/selenium-standalone-service": "^5.8.4",
     "allure-commandline": "^2.9.0",
     "codeceptjs": "^2.2.0",
-    "codeceptjs-saucelabs": "^1.0.7",
+    "codeceptjs-saucelabs": "^1.0.8",
     "codeceptjs-selenium": "^1.0.2",
     "debug": "^4.1.1",
     "deepmerge": "^3.2.0",

--- a/packages/codeceptjs-cucumber/package.json
+++ b/packages/codeceptjs-cucumber/package.json
@@ -22,7 +22,7 @@
     "@wdio/selenium-standalone-service": "^5.8.4",
     "allure-commandline": "^2.9.0",
     "codeceptjs": "^2.2.0",
-    "codeceptjs-saucelabs": "^1.0.9",
+    "codeceptjs-saucelabs": "^1.0.10",
     "codeceptjs-selenium": "^1.0.2",
     "debug": "^4.1.1",
     "deepmerge": "^3.2.0",

--- a/packages/codeceptjs-saucelabs/README.md
+++ b/packages/codeceptjs-saucelabs/README.md
@@ -33,9 +33,9 @@ In your `codeceptjs.conf.js`,
 
 Params to SauceLabs Config:
 
-* sauceUsername <required>
-* sauceKey <required>
-* userSpecificBrowsers <optional> //default browsers: `chrome`, `ie`, `edge`, `safari`, `firefox`
+* sauceUsername (required)
+* sauceKey (required)
+* userSpecificBrowsers (optional) //default browsers: `chrome`, `ie`, `edge`, `safari`, `firefox`
 
 Pass your Saucelabs Username, Access Key and UserSpecific Browser configuration 
 ```bash

--- a/packages/codeceptjs-saucelabs/README.md
+++ b/packages/codeceptjs-saucelabs/README.md
@@ -26,27 +26,29 @@ In your `codeceptjs.conf.js`,
 
 ```bash
     let merge = require('deepmerge');
-    let sauce = require('codeceptjs-saucelabs');
+    let codeceptJsSauce = require('codeceptjs-saucelabs');
 ```
 
 2. Deep Merge and export your **Config** 
 
+Params to SauceLabs Config:
+* sauceUsername <required>
+* sauceKey <required>
+* userSpecificBrowsers <optional> //default browsers: `chrome`, `ie`, `edge`, `safari`, `firefox`
+
+Pass your Saucelabs Username, Access Key and UserSpecific Browser configuration 
 ```bash
-   exports.config = merge(<your_existing_codeceptjs_conf>, sauce.conf);
+   exports.config = merge(<your_existing_codeceptjs_conf>, codeceptJsSauce.conf({
+		<sauceUsername>, 		//required
+		<sauceKey>,				//required
+		<userSpecificBrowsers>	//optional otherwise uses the default browser configuration
+   }));
+
 ```
+
+* Take look at the User-specific browsers configuration below
 
 You are all set!
-
-## Run
-
-**Important:** Make sure to export your Sauce Username and Sauce Access Key as env variables
-
-```bash
-    export SAUCE_USERNAME=<sauce_username>
-    export SAUCE_KEY=<sauce_key>
-```
-
-It uses CodeceptJS `--profile` param to run tests on Saucelabs browsers as described below,
 
 ### Run on Single browser on Saucelabs
 
@@ -67,3 +69,25 @@ It uses CodeceptJS `--profile` param to run tests on Saucelabs browsers as descr
 ```bash
     yarn acceptance:multibrowsers --grep @search_results --profile sauce:chrome,ie
 ```
+
+## User Specific Browser Configuration
+
+```bash
+	const userSpecificBrowsers = {
+            chrome: {
+                browser: 'chrome',
+                // add more configuration for Saucelabs platform
+            },
+            firefox: {
+                browser: 'firefox',
+            },
+            safari: {
+                browser: 'safari',
+            },
+            edge: {
+                browser: 'MicrosoftEdge',
+            }
+	}
+```
+
+

--- a/packages/codeceptjs-saucelabs/README.md
+++ b/packages/codeceptjs-saucelabs/README.md
@@ -41,11 +41,12 @@ Pass your Saucelabs Username, Access Key and UserSpecific Browser configuration
    exports.config = merge(<your_existing_codeceptjs_conf>, codeceptJsSauce.conf({
 		<sauceUsername>, 		//required
 		<sauceKey>,				//required
-		<userSpecificBrowsers>	//optional otherwise uses the default browser configuration
+		<userSpecificBrowsers>	//optional (otherwise uses the default browser configuration)
    }));
 
 ```
-
+*Note:* The User Specific Browser configuration will be merged to the default configuration
+ 
 * Take look at the User-specific browsers configuration below
 
 You are all set!

--- a/packages/codeceptjs-saucelabs/README.md
+++ b/packages/codeceptjs-saucelabs/README.md
@@ -32,17 +32,15 @@ In your `codeceptjs.conf.js`,
 2. Deep Merge and export your **Config** 
 
 Params to SauceLabs Config:
+
 * sauceUsername <required>
 * sauceKey <required>
 * userSpecificBrowsers <optional> //default browsers: `chrome`, `ie`, `edge`, `safari`, `firefox`
 
 Pass your Saucelabs Username, Access Key and UserSpecific Browser configuration 
 ```bash
-   exports.config = merge(<your_existing_codeceptjs_conf>, codeceptJsSauce.conf({
-		<sauceUsername>, 		//required
-		<sauceKey>,				//required
-		<userSpecificBrowsers>	//optional (otherwise uses the default browser configuration)
-   }));
+   
+   exports.config = merge(<your_existing_codeceptjs_conf>, codeceptJsSauce.conf(<sauceUsername>, <sauceKey>, <userSpecificBrowsers>));
 
 ```
 *Note:* The User Specific Browser configuration will be merged to the default configuration

--- a/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
+++ b/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
@@ -32,6 +32,9 @@ function config(sauceUsername, sauceKey, userSpecificBrowsers) {
     let conf = {
         helpers: {
             WebDriver: getBrowsers()[0],
+            SauceHelper: {
+                require: 'codeceptjs-saucehelper'
+            },
             REST: {}
         },
         plugins: {
@@ -57,6 +60,10 @@ function config(sauceUsername, sauceKey, userSpecificBrowsers) {
             process.env.SAUCE_KEY = sauceKey;
             conf.plugins.wdio.user = sauceUsername;
             conf.plugins.wdio.key = sauceKey;
+
+            // For supporting the codeceptjs-saucehelper module
+            conf.helpers.WebDriver.user = sauceUsername;
+            conf.helpers.WebDriver.key = sauceKey;
         }
         return conf;
     }

--- a/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
+++ b/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
@@ -1,12 +1,15 @@
-let sauceBrowsers = require('./sauce.browsers').browsers;
+let defaultBrowsers = require('./sauce.browsers').browsers;
 let debug = require('debug')('codeceptjs-saucelabs:config');
+let merge = require('deepmerge');
 
 const SAUCE_DELIMITER = ':';
 const MULTI_BROWSER_DELIMITER = ',';
 
 function config(sauceUsername, sauceKey, userSpecificBrowsers) {
 
-    sauceBrowsers = userSpecificBrowsers || sauceBrowsers;
+    sauceBrowsers = userSpecificBrowsers ? merge(userSpecificBrowsers, defaultBrowsers) : defaultBrowsers;
+
+    console.log(sauceBrowsers);
 
     function isSauceRequested() {
         return (process.profile && process.profile.match('sauce:[a-zA-Z]'));

--- a/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
+++ b/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
@@ -9,8 +9,6 @@ function config(sauceUsername, sauceKey, userSpecificBrowsers) {
 
     sauceBrowsers = userSpecificBrowsers ? merge(userSpecificBrowsers, defaultBrowsers) : defaultBrowsers;
 
-    console.log(sauceBrowsers);
-
     function isSauceRequested() {
         return (process.profile && process.profile.match('sauce:[a-zA-Z]'));
     }

--- a/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
+++ b/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
@@ -4,50 +4,52 @@ let debug = require('debug')('codeceptjs-saucelabs:config');
 const SAUCE_DELIMITER = ':';
 const MULTI_BROWSER_DELIMITER = ',';
 
-function isSauceRequested() {
-    return (process.profile && process.profile.match('sauce:[a-zA-Z]'));
-}
+function config(sauceUsername, sauceKey, userSpecificBrowsers) {
 
-function getBrowsers() {
-    if (isSauceRequested()) {
-        let multibrowsers = [];
-        let requestedBrowsers = process.profile.split(SAUCE_DELIMITER)[1].split(MULTI_BROWSER_DELIMITER);
-        debug('Tests are running on Saucelabs on Multi-Browsers:', requestedBrowsers);
-        requestedBrowsers.forEach(browser => {
-            multibrowsers.push(sauceBrowsers[browser]);
-        });
-        debug('Saucelabs Config for Multi-Browsers:', multibrowsers);
-        return multibrowsers;
+    sauceBrowsers = userSpecificBrowsers || sauceBrowsers;
+
+    function isSauceRequested() {
+        return (process.profile && process.profile.match('sauce:[a-zA-Z]'));
     }
 
-    return [sauceBrowsers.chrome];
-}
+    function getBrowsers() {
 
-
-let conf = {
-    helpers: {
-        WebDriver: getBrowsers()[0],
-        REST: {}
-    },
-    plugins: {
-        wdio: {
-            enabled: true,
-            services: ['sauce'],
-            user: process.env.SAUCE_USERNAME,
-            key: process.env.SAUCE_KEY,
-            region: 'us'
+        if (isSauceRequested()) {
+            let multibrowsers = [];
+            let requestedBrowsers = process.profile.split(SAUCE_DELIMITER)[1].split(MULTI_BROWSER_DELIMITER);
+            debug('Tests are running on Saucelabs on Multi-Browsers:', requestedBrowsers);
+            requestedBrowsers.forEach(browser => {
+                multibrowsers.push(sauceBrowsers[browser]);
+            });
+            debug('Saucelabs Config for Multi-Browsers:', multibrowsers);
+            return multibrowsers;
         }
-    },
-    multiple: {
-        multibrowsers: {
-            chunks: getBrowsers().length,
-            browsers: getBrowsers()
-        },
+
+        return [sauceBrowsers.chrome];
     }
-};
 
+    let conf = {
+        helpers: {
+            WebDriver: getBrowsers()[0],
+            REST: {}
+        },
+        plugins: {
+            wdio: {
+                enabled: true,
+                services: ['sauce'],
+                user: process.env.SAUCE_USERNAME,
+                key: process.env.SAUCE_KEY,
+                region: 'us'
+            }
+        },
+        multiple: {
+            multibrowsers: {
+                chunks: getBrowsers().length,
+                browsers: getBrowsers()
+            },
+        }
+    };
 
-function authenticate(sauceUsername, sauceKey) {
     if (isSauceRequested()) {
         if (sauceUsername && sauceKey) {
             process.env.SAUCE_USERNAME = sauceUsername;
@@ -57,7 +59,8 @@ function authenticate(sauceUsername, sauceKey) {
         }
         return conf;
     }
+
     return {};
 }
 
-exports.conf = authenticate;
+exports.conf = config;

--- a/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
+++ b/packages/codeceptjs-saucelabs/lib/codecept.sauce.conf.js
@@ -24,7 +24,14 @@ function getBrowsers() {
 
 let conf = {
   helpers: {
-    WebDriver: getBrowsers()[0]
+    WebDriver: {
+      browser: getBrowsers()[0].browser,
+      user: process.env.SAUCE_USERNAME,
+      key: process.env.SAUCE_KEY
+    },
+    SauceHelper: {
+      require: "codeceptjs-saucehelper"
+    }
   },
   plugins: {
     wdio: {

--- a/packages/codeceptjs-saucelabs/lib/sauce.browsers.js
+++ b/packages/codeceptjs-saucelabs/lib/sauce.browsers.js
@@ -5,12 +5,22 @@ let browsers = {
   },
   firefox: {
       browser: 'firefox',
+      capabilities: {
+          'sauce:options:': {
+              seleniumVersion: '3.11.0'
+          }
+      }
   },
   safari: {
       browser: 'safari',
   },
   edge: {
       browser: 'MicrosoftEdge',
+      capabilities: {
+        'sauce:options:': {
+            seleniumVersion: '3.11.0'
+        }
+    }
   },
   ie: {
       browser: 'internet explorer',

--- a/packages/codeceptjs-saucelabs/package-lock.json
+++ b/packages/codeceptjs-saucelabs/package-lock.json
@@ -1,9 +1,15 @@
 {
   "name": "codeceptjs-saucelabs",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "codeceptjs-saucehelper": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/codeceptjs-saucehelper/-/codeceptjs-saucehelper-1.3.0.tgz",
+      "integrity": "sha512-r+kbz/IKGqQL/ITsOyV2Hr5WIhLnlT1FnCsbnSDxuv9xUMLPhERqJKg6k+3BNZP1AfS36ZrDawevtawx+ywT9Q==",
+      "dev": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/packages/codeceptjs-saucelabs/package.json
+++ b/packages/codeceptjs-saucelabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-saucelabs",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "lib/codeceptjs-saucelabs.js",
   "description": "CodeceptJS Saucelabs Integration",
   "keywords": [

--- a/packages/codeceptjs-saucelabs/package.json
+++ b/packages/codeceptjs-saucelabs/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@wdio/sauce-service": "^5.9.3",
+    "codeceptjs-saucehelper": "^1.3.0",
     "debug": "^4.1.1",
     "deepmerge": "^3.2.0"
   },

--- a/packages/codeceptjs-saucelabs/package.json
+++ b/packages/codeceptjs-saucelabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-saucelabs",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "lib/codeceptjs-saucelabs.js",
   "description": "CodeceptJS Saucelabs Integration",
   "keywords": [

--- a/packages/codeceptjs-saucelabs/package.json
+++ b/packages/codeceptjs-saucelabs/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "devDependencies": {
     "@wdio/sauce-service": "^5.9.3",
+    "codeceptjs-saucehelper": "^1.3.0",
     "debug": "^4.1.1",
     "deepmerge": "^3.2.0"
   }

--- a/packages/codeceptjs-saucelabs/package.json
+++ b/packages/codeceptjs-saucelabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-saucelabs",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "lib/codeceptjs-saucelabs.js",
   "description": "CodeceptJS Saucelabs Integration",
   "keywords": [


### PR DESCRIPTION
Implementing the codeceptjs-saucehelper package for easier readability for tests on sauce labs. Displays test name with a pass or fail. Display issue with firefox/edge, but unsure if that's a local issue rather that a package issue. 